### PR TITLE
Doesn't always break the string correctly

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -158,7 +158,7 @@ export default class Parser extends Writable {
 	 * @return {object}     {name, attributes}
 	 */
 	_parseTagString(str) {
-		let [name, ...attrs] = str.split(/\s+(?=[\w:]+=)/g);
+		let [name, ...attrs] = str.split(/\s+(?=[\w-:]+=)/g);
 		let attributes = {};
 		attrs.forEach(attribute => {
 			let [name, value] = attribute.split('=');


### PR DESCRIPTION
In my  case:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<realty-feed xmlns="http://webmaster.yandex.ru/schemas/feed/realty/2010-06">
  <generation-date>2020-05-17T15:10:00.239147+03:00</generation-date>
  
    <offer internal-id="73a2028f-7544-e811-80de-005056b8d207"> <!-- look here !-->
      
      <type>sale</type>
      <property-type>living</property-type>
<!-- .... !-->
````
![image](https://user-images.githubusercontent.com/25330618/82148312-1aaa4100-985c-11ea-90c2-041d15b8b677.png)
